### PR TITLE
tasks: kernel: exclude devices with their own kernel script

### DIFF
--- a/core/tasks/kernel.mk
+++ b/core/tasks/kernel.mk
@@ -1,3 +1,6 @@
+# Exclude Sony devices using their own kernel building script
+ifneq ($(BUILD_KERNEL),true)
+
 # Android makefile to build the Kernel as a part of the Android build-system
 PERL		= perl
 
@@ -199,3 +202,5 @@ $(file) : $(TARGET_PREBUILT_INT_KERNEL) | $(ACP)
 	$(transform-prebuilt-to-target)
 
 ALL_PREBUILT += $(INSTALLED_KERNEL_TARGET)
+
+endif # BUILD_KERNEL


### PR DESCRIPTION
Sony devices use their own kernel building script

Change-Id: I87852024c9c090dd7c942bbd5dda511d07b6896f